### PR TITLE
Fix Microsoft login on mobile app

### DIFF
--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -30,8 +30,7 @@ export default class Auth {
             '&redirect_uri=' + this.redirect_uri +
             '&scope=' + this.scope +
             '&response_mode=query' +
-            '&nonce=' + uuid.v4() +
-            '&state=abcd';
+            '&nonce=' + uuid.v4()
     }
 
     _request(params: any): Promise {

--- a/lib/AzureLoginView.js
+++ b/lib/AzureLoginView.js
@@ -37,6 +37,16 @@ export default class AzureLoginView extends React.Component {
 	}
 
 	_handleTokenRequest(e:{ url:string }):any{
+		
+		// stop loading if we hit the redirect URI, because otherwise it will 
+		// error out. (Android specific, as mentioned in 
+		// https://james1888.github.io/posts/react-native-prevent-webview-redirect/)
+		if (e.url == this.auth.redirect_uri) {
+			if (!!this.webView && !!this.webView.stopLoading) {
+				this.webView.stopLoading()
+			}
+		}
+		
 		// get code when url chage
 		let code = /((\?|\&)code\=)[^\&]+/.exec(e.url);
 
@@ -94,10 +104,16 @@ export default class AzureLoginView extends React.Component {
 					decelerationRate="normal"
 					javaScriptEnabledAndroid={true}
 					onNavigationStateChange={this._handleTokenRequest}
-					onShouldStartLoadWithRequest={(e) => {return true}}
+					// handling redirects on iOS -- don't allow loading
+					// if it's the redirect URI.
+					// With reference to https://james1888.github.io/posts/react-native-prevent-webview-redirect/
+					onShouldStartLoadWithRequest={ ({ url }) => { 
+						return this.auth.redirect_uri && !url.startsWith(this.auth.redirect_uri)
+					}}
 					startInLoadingState={true}
 					injectedJavaScript={js}
 					scalesPageToFit={true}
+					ref={c => { this.webView = c }}
 				/> ) : this._renderLoadingView()
 		)
    	}


### PR DESCRIPTION
This _might_ fix the intermittent Microsoft login issue. The reason this is happening is because the WebView is being redirected to our OAuth callback (which is the right thing to do on the Web when it has a valid `state` parameter that is a JSON Web Token). On mobile, it should just take the OAuth authorization code, the `code` parameter, but not navigate to the OAuth callback. 

Referred to https://james1888.github.io/posts/react-native-prevent-webview-redirect/ to figure out how to stop the webview navigating on both iOS and Android. Need your opinion about whether the solution proposed works.

